### PR TITLE
Show more information in the .md files

### DIFF
--- a/issuesync.rb
+++ b/issuesync.rb
@@ -85,6 +85,7 @@ class IssueSync
         title << " [#{label}]"
       end
       title << " [CLOSED]" if issue.closed?
+      title = title.strip
 
       io.puts title
       io.puts "=" * title.size

--- a/issuesync.rb
+++ b/issuesync.rb
@@ -82,7 +82,7 @@ class IssueSync
     def format_body(io, issue)
       title = "##{issue.number}: #{issue.title.strip} "
       for label in issue.labels
-        title << " [" + label + "]"
+        title << " [#{label}]"
       end
       title << " [CLOSED]" if issue.closed?
 

--- a/issuesync.rb
+++ b/issuesync.rb
@@ -80,6 +80,7 @@ class IssueSync
 
     def format_body(io, issue)
       title = "##{issue.number}: #{issue.title.strip}"
+      title << issue.labels
       title << "  [CLOSED]" if issue.closed?
 
       io.puts title
@@ -228,6 +229,14 @@ class IssueSync
     def has_comments?() !data['comments'].zero? end
     def open?() data['state'] == 'open' end
     def closed?() !open? end
+
+    def labels()
+      s = ""
+      for label in data['labels']
+        s << "  _" + label['name'] + "_"
+      end
+      s
+    end
   end
 
   class Comment < Issue

--- a/issuesync.rb
+++ b/issuesync.rb
@@ -80,9 +80,11 @@ class IssueSync
     end
 
     def format_body(io, issue)
-      title = "##{issue.number}: #{issue.title.strip}"
-      title << issue.labels
-      title << "  [CLOSED]" if issue.closed?
+      title = "##{issue.number}: #{issue.title.strip} "
+      for label in issue.labels
+        title << " [" + label + "]"
+      end
+      title << " [CLOSED]" if issue.closed?
 
       io.puts title
       io.puts "=" * title.size
@@ -250,14 +252,7 @@ class IssueSync
     def has_comments?() !data['comments'].zero? end
     def open?() data['state'] == 'open' end
     def closed?() !open? end
-
-    def labels()
-      s = ""
-      for label in data['labels']
-        s << "  _" + label['name'] + "_"
-      end
-      s
-    end
+    def labels() data['labels'].map {|x| x['name']} end
   end
 
   class Comment < Issue

--- a/issuesync.rb
+++ b/issuesync.rb
@@ -85,6 +85,8 @@ class IssueSync
       io.puts title
       io.puts "=" * title.size
       io.puts
+      io.puts "## #{issue.user}"
+      io.puts
       io.puts issue.body
     end
 


### PR DESCRIPTION
I categorise my issues with labels on my bigger projects, so having the labels available is handy.

I also find it very useful to see who opened a ticket.