### PR TITLE
Use `git remote` command to find remote URLs

### DIFF
--- a/issuesync.rb
+++ b/issuesync.rb
@@ -266,7 +266,9 @@ class IssueSync
 end
 
 if __FILE__ == $0
-  File.readlines('.git/config').find {|rem| %r{github\.com[:/](.+?)/(.+?)(\.git)?$} =~ rem }
+  remotes = `git remote`.lines
+  remote_urls = remotes.map {|remote| `git remote get-url #{remote}` }
+  remote_urls.find {|rem| %r{github\.com[:/](.+?)/(.+?)(\.git)?$} =~ rem }
   repo_with_owner = "#$1/#$2" if $1
   abort "no GitHub repo found among git remotes" if repo_with_owner.nil?
 


### PR DESCRIPTION
Fixes #6 

I took a look at the output of `git remote -v`, but each line ends in ` (fetch)` or ` (push)`, so I would have needed to change the regex. I think it's best to feed the regex clean data so that the regex can stay simple.