### PR TITLE
Fixed a permissions bug and improved usage of Net::HTTP::Persistent

### DIFF
--- a/issuesync.rb
+++ b/issuesync.rb
@@ -160,7 +160,7 @@ class IssueSync
 
     def http
       @http ||= begin
-        conn = Net::HTTP::Persistent.new self.class.name, proxy_uri
+        conn = Net::HTTP::Persistent.new name: self.class.name, proxy: proxy_uri
         conn.debug_output = $stderr if $DEBUG
         conn
       end

--- a/issuesync.rb
+++ b/issuesync.rb
@@ -160,7 +160,11 @@ class IssueSync
 
     def http
       @http ||= begin
-        conn = Net::HTTP::Persistent.new name: self.class.name, proxy: proxy_uri
+        conn = if Net::HTTP::Persistent::VERSION.to_i < 3
+          Net::HTTP::Persistent.new self.class.name, proxy_uri
+        else
+          Net::HTTP::Persistent.new name: self.class.name, proxy: proxy_uri
+        end
         conn.debug_output = $stderr if $DEBUG
         conn
       end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -26,7 +26,7 @@ task :install do
     abort "aborted: `#{exefile}' already exists"
   end
 
-  File.open(exefile, 'w', 755) do |exe|
+  File.open(exefile, 'w', 0755) do |exe|
     exe.puts "#!/bin/sh"
     exe.puts "'#{ruby}' '#{here}/issuesync.rb'"
   end


### PR DESCRIPTION
[File.open](https://ruby-doc.org/core-2.1.4/File.html) in its 3-argument version, takes the permissions argument
in octal, not decimal.  The constructor for Net::HTTP::persistent was
throwing an error [1] causing issuesync to stop at that point (so it wasn't
pulling the issues). Named arguments are now being used instead, which
is a more explicit form of calling it, and at the same time the error
goes away.

Thanks for writing issuesync! It's a awesome project of great practical value! :beer: :+1: 

[1]
```
/home/user/gems/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:505:in initialize:
wrong number of arguments (given 2, expected 0) (ArgumentError)
	from /tmp/issuesync/issuesync.rb:163:in new
	from /tmp/issuesync/issuesync.rb:163:in http
	from /tmp/issuesync/issuesync.rb:195:in get_response
	from /tmp/issuesync/issuesync.rb:184:in get
	from /tmp/issuesync/issuesync.rb:110:in raw_issues
	from /tmp/issuesync/issuesync.rb:114:in issues
	from /tmp/issuesync/issuesync.rb:118:in call
	from /tmp/issuesync/issuesync.rb:49:in start
	from /tmp/issuesync/issuesync.rb:30:in start
	from /tmp/issuesync/issuesync.rb:275:in <main>
```

